### PR TITLE
Add: url for health probe, which always returns 200

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -4,6 +4,11 @@ server {
     listen       80;
     server_name  localhost;
 
+    location /healthz {
+        access_log off;
+        return 200;
+    }
+
     location / {
         # IPv4 can simply be redirected to the CDN; this gives better
         # performance, as they can end on an edge closer to them.


### PR DESCRIPTION
We cannot trust any URL to give a correct response, as we are not
in control of that data.