### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -1,13 +1,9 @@
 notifications:
-  push:
+  global:
     irc:
-      - openttd
-      - openttd.notice
+    - openttd
+    - openttd.notice
+
   pull-request:
-    irc:
-      - openttd
-      - openttd.notice
   issue:
-    irc:
-      - openttd
-      - openttd.notice
+  tag-created:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,40 @@
+name: Deployment
+
+on:
+  deployment:
+
+jobs:
+  deploy_to_aws:
+    name: Deploy to AWS
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deployment in progress
+      uses: openttd/actions/deployments-update@v1
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        state: in_progress
+        description: "Deployment of ${{ github.event.deployment.payload.version }} to ${{ github.event.deployment.environment }} started"
+
+    - name: Deploy on AWS
+      uses: openttd/actions/deploy-aws@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ secrets.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        name: BinariesProxy
+
+    - if: success()
+      name: Deployment successful
+      uses: openttd/actions/deployments-update@v1
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        state: success
+        description: "Successfully deployed ${{ github.event.deployment.payload.version }} on ${{ github.event.deployment.environment }}"
+
+    - if: failure() || cancelled()
+      name: Deployment failed
+      uses: openttd/actions/deployments-update@v1
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        state: failure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish image
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+  repository_dispatch:
+    types:
+    - publish_latest_tag
+    - publish_master
+
+jobs:
+  publish_image:
+    name: Publish image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - if: github.event_name == 'repository_dispatch'
+      name: Repository dispatch
+      uses: openttd/actions/dispatch@v1
+
+    - name: Checkout tags and submodules
+      uses: openttd/actions/checkout@v1
+      with:
+        with-tags: true
+        with-submodules: false
+
+    - name: Set variables
+      id: vars
+      uses: openttd/actions/docker-vars@v1
+      with:
+        docker-hub-username: ${{ secrets.DOCKER_USERNAME }}
+
+    - name: Build
+      uses: openttd/actions/docker-build@v1
+      with:
+        name: ${{ steps.vars.outputs.name }}
+        tag: ${{ steps.vars.outputs.tag }}
+        tags: ${{ steps.vars.outputs.tags }}
+        version: ${{ steps.vars.outputs.version }}
+        date: ${{ steps.vars.outputs.date }}
+
+    - if: steps.vars.outputs.dry-run == 'false'
+      name: Publish
+      id: publish
+      uses: openttd/actions/docker-publish@v1
+      with:
+        docker-hub-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-hub-password: ${{ secrets.DOCKER_PASSWORD }}
+        name: ${{ steps.vars.outputs.name }}
+        tag: ${{ steps.vars.outputs.tag }}
+
+    - if: steps.vars.outputs.dry-run == 'false'
+      name: Trigger deployment
+      uses: openttd/actions/deployments-create@v1
+      with:
+        ref: ${{ steps.vars.outputs.sha }}
+        environment: ${{ steps.vars.outputs.environment }}
+        version: ${{ steps.vars.outputs.version }}
+        date: ${{ steps.vars.outputs.date }}
+        docker-tag: ${{ steps.publish.outputs.remote-tag }}
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,17 @@
+name: Testing
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,11 @@
 FROM nginx:alpine
+
+ARG BUILD_DATE=""
+ARG BUILD_VERSION="dev"
+
+LABEL maintainer="truebrain@openttd.org"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=${BUILD_DATE}
+LABEL org.label-schema.version=${BUILD_VERSION}
+
 COPY nginx.default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This deprecates Azure Pipelines. It is kept in for now, so we can make a smooth transition.

Currently blocked by https://github.com/OpenTTD/actions/pull/1