### PR TITLE
Fix: no longer log 2XX/3XX with this Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=${BUILD_DATE}
 LABEL org.label-schema.version=${BUILD_VERSION}
 
+RUN sed -i 's/access_log/# access_log/g' /etc/nginx/nginx.conf
 COPY nginx.default.conf /etc/nginx/conf.d/default.conf

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -1,3 +1,14 @@
+# Don't log 2XX and 3XX to spot problems quickly.
+# In the way this Docker is used in production, there is always a
+# webserver in front of it, logging everything. By minimizing what this
+# Docker is logging, we can easier see what is going wrong.
+map $status $loggable {
+    ~^[23]  0;
+    default 1;
+}
+
+access_log /var/log/nginx/access.log main if=$loggable;
+
 proxy_cache_path /tmp/nginx-cache/ levels=1:2 keys_zone=nginx-cache:16m max_size=1g inactive=60m use_temp_path=off;
 
 server {


### PR DESCRIPTION
In the way this Docker is used in production, there is always a
webserver in front of it, logging everything. By minimizing what this
Docker is logging, we can easier see what is going wrong.